### PR TITLE
Travis-ci: added support for ppc64le & updated latest go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: go
-
+arch:
+  - AMD64
+  - ppc64le
 go:
-  - 1.7
-  - 1.8
-  - 1.9
-  - 1.10
-  - 1.11
   - 1.12
+  - 1.13
+  - 1.14
+  - 1.15
 
 script:
   - go test


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le and updated latest go versions 1.13, 1.14 & 1.15. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.